### PR TITLE
Added Typescript Type Definitions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
   "scripts": {
     "example": "node example/example",
     "lint": "standard",
+    "test:types": "tsd",
     "test:unit": "tap -J test/*.test.js test/*/*.test.js",
-    "test": "npm run lint && npm run test:unit"
+    "test": "npm run lint && npm run test:unit && npm run test:types"
   },
   "dependencies": {
     "fastify-plugin": "^1.5.0"
@@ -17,7 +18,11 @@
     "fastify": "^2.0.0",
     "simple-get": "^3.0.3",
     "standard": "^12.0.1",
-    "tap": "^12.5.3"
+    "tap": "^12.5.3",
+    "tsd": "^0.11.0"
+  },
+  "tsd": {
+    "directory": "test"
   },
   "peerDependencies": {},
   "engines": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.0",
   "description": "Fastify plugin to serve default favicon requests",
   "main": "src/plugin",
+  "types": "src/plugin.d.ts",
   "scripts": {
     "example": "node example/example",
     "lint": "standard",

--- a/src/plugin.d.ts
+++ b/src/plugin.d.ts
@@ -1,7 +1,7 @@
 import * as fastify from 'fastify';
 import * as http from 'http';
 
-interface FastifyFaviconOptions {
+export interface FastifyFaviconOptions {
     path?: string;
 }
 
@@ -12,4 +12,4 @@ declare const fastifyFavicon: fastify.Plugin<
     FastifyFaviconOptions
 >;
 
-export = fastifyFavicon;
+export default fastifyFavicon;

--- a/src/plugin.d.ts
+++ b/src/plugin.d.ts
@@ -1,0 +1,15 @@
+import * as fastify from 'fastify';
+import * as http from 'http';
+
+interface FastifyFaviconOptions {
+    path?: string;
+}
+
+declare const fastifyFavicon: fastify.Plugin<
+    http.Server,
+    http.IncomingMessage,
+    http.ServerResponse,
+    FastifyFaviconOptions
+>;
+
+export = fastifyFavicon;

--- a/test/plugin.test-d.ts
+++ b/test/plugin.test-d.ts
@@ -1,0 +1,8 @@
+import fastify = require('fastify');
+import { expectAssignable } from 'tsd';
+import fastifyFavicon, { FastifyFaviconOptions } from '../src/plugin';
+
+fastify().register(fastifyFavicon, { path: "blah/blah/blah" });
+
+expectAssignable<FastifyFaviconOptions>({});
+expectAssignable<FastifyFaviconOptions>({ path: "blah/blah/blah" });


### PR DESCRIPTION
Typescript Type Definitions are added into src/plugin.d.ts.

This definition only works for Fastify v2.0. When this plugin is upgraded to support Fastify v3.0, I will update the definitions accordingly.