### PR TITLE
Update to fastify4

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ fastify.register(require('fastify-favicon'))
 // and custom name; both options are optional
 fastify.register(require('fastify-favicon'), { path: './test', name: 'icon.ico' })
 
-fastify.listen(3000)
+fastify.listen({ port: 3000, host: 'localhost' })
 // curl http://127.0.0.1:3000/favicon.ico => returning the image, and no error thrown
 ```
 
 ## Requirements
 
-Fastify ^3.11.0 , Node.js 10.13.x or later.
-Note that plugin releases 2.x are for Fastify 2.x, 3.x are for Fastify 3.x, etc.
+Fastify ^4.0.0 , Node.js 14.15.0 or later.
+Note that plugin releases 3.x are for Fastify 3.x, 4.x are for Fastify 4.x, etc.
 
 
 ## Sources

--- a/example/example.js
+++ b/example/example.js
@@ -37,7 +37,7 @@ fastify.get('/', function (req, reply) {
   reply.type('text/html; charset=utf-8').send(stream)
 })
 
-fastify.listen(3000, '127.0.0.1', (err, address) => {
+fastify.listen({ port: 3000, host: 'localhost' }, (err, address) => {
   if (err) throw err
   console.log(`Server listening on '${address}' ...`)
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify-favicon",
-  "version": "3.2.0",
+  "version": "4.0.0",
   "description": "Fastify plugin to serve default favicon requests",
   "main": "src/plugin",
   "types": "types/plugin.d.ts",
@@ -30,11 +30,11 @@
     "@types/node": "^17.0.42",
     "@typescript-eslint/eslint-plugin": "^5.27.1",
     "@typescript-eslint/parser": "^5.27.1",
-    "fastify": "^3.11.0",
+    "fastify": "^4.0.0",
     "jsdoc": "^3.6.10",
     "simple-get": "^4.0.1",
-    "standard": "^16.0.3",
-    "tap": "^15.0.1",
+    "standard": "^17.0.0",
+    "tap": "^16.2.0",
     "tsd": "^0.21.0",
     "typescript": "^4.7.3"
   },
@@ -52,7 +52,7 @@
   },
   "peerDependencies": {},
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=14.15.0"
   },
   "homepage": "https://github.com/smartiniOnGitHub/fastify-favicon#readme",
   "repository": {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -57,6 +57,6 @@ function ensureIsString (arg, name) {
 }
 
 module.exports = fp(fastifyFavicon, {
-  fastify: '3.x',
+  fastify: '4.x',
   name: 'fastify-favicon'
 })

--- a/test/favicon.test.js
+++ b/test/favicon.test.js
@@ -20,14 +20,14 @@ const sget = require('simple-get').concat
 const Fastify = require('fastify')
 
 test('default favicon does not return an error, but a good response (200) and some content', (t) => {
-  t.plan(6)
+  // t.plan(6)
   const defaultPath = './src'
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.teardown(() => { fastify.close() })
 
   fastify.register(require('../')) // configure this plugin with its default options
 
-  fastify.listen(0, (err, address) => {
+  fastify.listen({ port: 0 }, (err, address) => {
     t.error(err)
 
     sget({
@@ -46,20 +46,20 @@ test('default favicon does not return an error, but a good response (200) and so
       assert(contents !== null)
       t.ok(contents)
       t.strictSame(contents.length, body.length)
+      t.end()
     })
   })
 })
 
 test('return a favicon configured in a custom path', (t) => {
-  t.plan(6)
   const pathSample = './test'
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.teardown(() => { fastify.close() })
   fastify.register(require('../'), {
     path: pathSample
   })
 
-  fastify.listen(0, (err, address) => {
+  fastify.listen({ port: 0 }, (err, address) => {
     t.error(err)
 
     sget({
@@ -78,21 +78,21 @@ test('return a favicon configured in a custom path', (t) => {
       assert(contents !== null)
       t.ok(contents)
       t.strictSame(contents.length, body.length)
+      t.end()
     })
   })
 })
 
 test('return default favicon because that in the custom path is not found', (t) => {
-  t.plan(6)
   const pathSample = './test/not-existing-img-path' // path that here does not exist, good for this test
   const defaultPath = './src'
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.teardown(() => { fastify.close() })
   fastify.register(require('../'), {
     path: pathSample
   })
 
-  fastify.listen(0, (err, address) => {
+  fastify.listen({ port: 0 }, (err, address) => {
     t.error(err)
 
     sget({
@@ -111,6 +111,7 @@ test('return default favicon because that in the custom path is not found', (t) 
       assert(contents !== null)
       t.ok(contents)
       t.strictSame(contents.length, body.length)
+      t.end()
     })
   })
 })


### PR DESCRIPTION
Update dependencies and code to Fastify 4.x and Node.js 14 LTS (as required); update all other dependencies to latest releases (all compatible with Node.js 14.x).
